### PR TITLE
CLOUD-642 Install cbd to a directory which is available on PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Install cbd to a directory which is available on $PATH
+
 ### Removed
 
 ### Changed
@@ -142,6 +144,6 @@ Added
 
 - help command added
 - version command added
-- Added --version 
+- Added --version
 - CircleCI build
 - Linux/Darwin binary releases on github

--- a/install
+++ b/install
@@ -2,6 +2,12 @@
 : ${GIT_ORG:=sequenceiq}
 : ${GIT_PROJECT:=cloudbreak-deployer}
 
+contains_element() {
+    local e
+    for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
+    return 1
+}
+
 main() {
     local redirect=$(
     curl -s \
@@ -14,8 +20,18 @@ main() {
 
     local url="https://github.com/${GIT_ORG}/${GIT_PROJECT}/releases/download/v${latest}/${GIT_PROJECT}_${latest}_${osarch}.tgz"
 
-    curl -Ls $url | tar -xz -C /usr/local/bin/
+    local supported_install_location=("/usr/local/bin" "/usr/bin" "/bin")
+    IFS=':' read -a env_path <<< "$PATH"
+
+    for i in "${env_path[@]}"
+    do
+      if contains_element "$i" "${supported_install_location[@]}";
+      then
+        curl -Ls $url | tar -xz -C $i
+        echo "cbd has been installed to $i"
+        break;
+      fi
+    done
 }
 
 main
-


### PR DESCRIPTION
On CentOS 6.x by default the PATH variable does not contain the /usr/local/bin
