### PR TITLE
CLOUD-769 save logs before killing containers

### DIFF
--- a/include/compose.bash
+++ b/include/compose.bash
@@ -41,6 +41,20 @@ compose-up() {
 compose-kill() {
     declare desc="Kills and removes all cloudbreak related container"
 
+    dateofdeletion=$(date +"%Y-%m-%d_%H-%M-%S")
+    if boot2docker version &> /dev/null; then
+        # this is for OSX
+        logsdestination=/tmp/cbd-logs/$dateofdeletion
+    else
+        # this is for linux
+        logsdestination=/var/log/cbd-logs/$dateofdeletion
+    fi
+    mkdir -p $logsdestination
+    for containerid in `dockerCompose ps -q`; do
+        containername=$(docker inspect -f {{.Name}} $containerid|sed 's/\///g')
+        docker logs $containerid &> $logsdestination/$containername.log
+    done
+
     dockerCompose kill
     dockerCompose rm -f
 }


### PR DESCRIPTION
@lalyos or @akanto or @keyki please review it!
This is a temporary solution to save containers' logs that created by **cbd tool** before the '*cbd kill*' command deletes them.

The logs are copied under:
 - '*/tmp/cbd-logs/*' dir in case of OSX
 - '*/var/log/cbd-logs/*' dir in case of Linux