### PR TITLE
share certs volume with periscope

### DIFF
--- a/include/compose.bash
+++ b/include/compose.bash
@@ -327,6 +327,8 @@ periscope:
         - ambassador:backend
     ports:
         - 8085:8080
+    volumes:
+        - "$CBD_CERT_ROOT_PATH:/certs"
     image: sequenceiq/periscope:$DOCKER_TAG_PERISCOPE
 
 EOF


### PR DESCRIPTION
@lalyos 
Periscope uses the same /certs directory as default to read the certificates to access Ambari.