### PR TITLE
CLOUD-41629: Change the created 'certs' directory's owner to the current user

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -193,6 +193,8 @@ cloudbreak-generate-cert() {
     else
       info "Generating Cloudbreak client certificate and private key in ${CBD_CERT_ROOT_PATH}."
       docker run --rm -v ${CBD_CERT_ROOT_PATH}:/certs ehazlett/cert-tool:${DOCKER_TAG_CERT_TOOL} -d /certs -o=local &> /dev/null
+      owner=$(ls -od ${CBD_CERT_ROOT_PATH} | tr -s ' ' | cut -d ' ' -f 3)
+      [[ "$owner" != "$(whoami)" ]] && sudo chown -R $(whoami):$(id -gn) ${CBD_CERT_ROOT_PATH}
       cat "${CBD_CERT_ROOT_PATH}/ca.pem" >> "${CBD_CERT_ROOT_PATH}/client.pem"
       mv "${CBD_CERT_ROOT_PATH}/ca.pem" "${CBD_CERT_ROOT_PATH}/client-ca.pem"
       mv "${CBD_CERT_ROOT_PATH}/ca-key.pem" "${CBD_CERT_ROOT_PATH}/client-ca-key.pem"


### PR DESCRIPTION
@akanto or @lalyos pls review...

* On osx the created certs directory's owner is ok, in linux case the certs directory's owner will be root, so we have to change it. For this the user have to be a sudoer.
* Other criteria: The user have to be in the 'docker' group.
