### PR TITLE
Add gnu-sed 4.2.2 binary dependency

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- binary version of gnu-sed 4.2.2 is now included, to solve lot of osx/busybox issues
+
 ### Removed
 
 ### Changed

--- a/include/deployer.bash
+++ b/include/deployer.bash
@@ -219,6 +219,7 @@ main() {
     cbd-find-root
     deps-init
 	color-init
+    deps-require sed
     load-profile "$@"
 
     circle-init


### PR DESCRIPTION
See:
- https://github.com/sequenceiq/docker-gnused-linux-bin
- https://github.com/sequenceiq/gnused-osx-bin
- https://github.com/lalyos/glidergun-rack/blob/master/index/sed