### PR TITLE
consul recursors should exclude docker ip (boot2docker ip, or docker-machine ip)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+- consul recursor now exculdes both docker ip and bridge ip to avoid recursive dns recursor chain
+
 ### Added
 
 - Command `cbd start` will execute the migration by default. If SKIP_DB_MIGRATION_ON_START envvar set to true in Profile, the migration will be skipped

--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -42,21 +42,31 @@ cloudbreak-conf-tags() {
     env-import CB_DOCKER_CONTAINER_AMBARI_WARM ""
 }
 
+docker-ip() {
+    if [[ $DOCKER_HOST =~ "tcp://" ]];then
+        local dip=${DOCKER_HOST#*//}
+        echo ${dip%:*}
+    else
+        echo none
+    fi
+}
+
 consul-recursors() {
     declare desc="Generates consul agent recursor option, by reading the hosts resolv.conf"
     declare resolvConf=${1:? 'required 1.param: resolv.conf file'}
     declare bridge=${2:? 'required 2.param: bridge ip'}
+    declare dockerIP=${3:- none}
 
     local nameservers=$(sed -n "/nameserver/ s/^.*nameserver[^0-9]*//p;" $resolvConf)
     debug "nameservers on host:\n$nameservers"
     debug bridge=$bridge
-    echo "$nameservers" | grep -v $bridge | sed -n '{s/^/ -recursor /;H;}; $ {x;s/[\n\r]//g;p}'
+    echo "$nameservers" | grep -v "$bridge\|$dockerIP" | sed -n '{s/^/ -recursor /;H;}; $ {x;s/[\n\r]//g;p}'
 }
 
 cloudbreak-conf-consul() {
     env-import DOCKER_CONSUL_OPTIONS ""
     if ! [[ $DOCKER_CONSUL_OPTIONS =~ .*recursor.* ]]; then
-        DOCKER_CONSUL_OPTIONS="$DOCKER_CONSUL_OPTIONS $(consul-recursors <(docker run -it --rm --net=host alpine cat /etc/resolv.conf) $(bridge-ip))"
+        DOCKER_CONSUL_OPTIONS="$DOCKER_CONSUL_OPTIONS $(consul-recursors <(docker run -it --rm --net=host alpine cat /etc/resolv.conf) $(bridge-ip) $(docker-ip))"
     fi
     debug "DOCKER_CONSUL_OPTIONS=$DOCKER_CONSUL_OPTIONS"
 }

--- a/test/cloudbreak.bash
+++ b/test/cloudbreak.bash
@@ -37,3 +37,17 @@ EOF
     [[ "$result" == "$expected" ]] || $T_fail "expected=\'$expected\' but actual=\'$result\'"
 }
 
+T_consulRecursorOneValidBridgeAndDockerIpShouldbeExcluded() {
+    result=$(consul-recursors <(cat <<EOF
+nameserver 1.2.3.4
+nameserver 172.17.42.1
+nameserver 192.168.59.103
+nameserver 1.1.1.1
+EOF
+) 172.17.42.1 192.168.59.103)
+
+    local expected=" -recursor 1.2.3.4 -recursor 1.1.1.1"
+    [[ "$result" == "$expected" ]] || $T_fail "expected=\'$expected\' but actual=\'$result\'"
+}
+
+


### PR DESCRIPTION
Fixes #123