### PR TITLE
Runtime migration

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -23,18 +23,18 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_ALPINE 3.1
     env-import DOCKER_TAG_CONSUL 0.5
     env-import DOCKER_TAG_REGISTRATOR v5
-    env-import DOCKER_TAG_CLOUDBREAK 1.1.0-rc.47
+    env-import DOCKER_TAG_CLOUDBREAK 1.2.0-dev.210
     env-import DOCKER_TAG_CBDB 1.1.0-rc.28
     env-import DOCKER_TAG_POSTGRES 9.4.1
-    env-import DOCKER_TAG_PERISCOPE 1.0.0-rc.3
+    env-import DOCKER_TAG_PERISCOPE 1.1.0-dev.1
     env-import DOCKER_TAG_PCDB 1.0.0-rc.3
     env-import DOCKER_TAG_UAA 2.7.1
     env-import DOCKER_TAG_UAADB v2.7.1
-    env-import DOCKER_TAG_ULUWATU 1.1.0-rc.20
-    env-import DOCKER_TAG_SULTANS 1.1.0-rc.5
+    env-import DOCKER_TAG_ULUWATU 1.2.0-dev.51
+    env-import DOCKER_TAG_SULTANS 1.2.0-dev.8
     env-import DOCKER_TAG_AMBASSADOR 0.5.0
     env-import DOCKER_TAG_CERT_TOOL 0.0.3
-    env-import DOCKER_TAG_CLOUDBREAK_SHELL 0.5.38
+    env-import DOCKER_TAG_CLOUDBREAK_SHELL 1.2.0-dev.11
 
     env-import CB_DOCKER_CONTAINER_AMBARI ""
     env-import CB_DOCKER_CONTAINER_AMBARI_WARM ""


### PR DESCRIPTION
@akanto or @lalyos please review!

Changes:
- The `migrate` command was modified to only migrate the uaadb, because Cloudbreak and Periscope have their own runtime database migration mechanisms.
- The previous change requires the latest version from Cloudbreak and Periscope so I built and updated the defaults to use the latest development versions from the components' docker images.