### PR TITLE
CLOUD-60634 modify cbd util local-dev to set labels for ambassador

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -464,6 +464,10 @@ HINT
         -p 8080:8080 \
         -e PORT=8080 \
         -e SERVICE_NAME=cloudbreak \
+        -l traefik.port=8080 \
+        -l traefik.frontend.rule=PathPrefix:/cb/ \
+        -l traefik.backend=cloudbreak-backend \
+        -l traefik.frontend.priority=10 \
         sequenceiq/ambassadord:$DOCKER_TAG_AMBASSADOR $CB_LOCAL_DEV_BIND_ADDR:$port
 
 }


### PR DESCRIPTION
@lalyos or @akanto 
To Cloudbreak shell and CURLs work through https on local dev environment.