### PR TITLE
custom traefik tls option (for prod/qa/preprod)

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -125,6 +125,8 @@ cloudbreak-conf-db() {
 cloudbreak-conf-cert() {
     declare desc="Declares cloudbreak cert config"
     env-import CBD_CERT_ROOT_PATH "${PWD}/certs"
+
+    env-import CBD_TRAEFIK_TLS "/certs/client-ca.pem,/certs/client-ca-key.pem"
 }
 
 cloudbreak-delete-dbs() {

--- a/include/compose.bash
+++ b/include/compose.bash
@@ -211,7 +211,7 @@ traefik:
     command: --debug --web \
         --defaultEntryPoints=http,https \
         --entryPoints='Name:http Address::80 Redirect.EntryPoint:https' \
-        --entryPoints='Name:https Address::443 TLS:/certs/client-ca.pem,/certs/client-ca-key.pem' \
+        --entryPoints='Name:https Address::443 TLS:$CBD_TRAEFIK_TLS' \
         --docker
 haveged:
     labels:


### PR DESCRIPTION
custom traefik tls option:

all TLS is terminated by traefik. certificate and keyy is stored in: `$CBD_DIR/certs`.

By default the a cert(and key) is used which is always created for the communication channel between cloudbreak and the provisioned HDP cluster.

In case the cloudbreak deployment has its own DNS name (like prod/qa/preprod) you probably bring your own certificates. Copu them into: `$CBD_DIR/certs` and define a custome env var in `Profile`:

```
export CBD_TRAEFIK_TLS=/certs/seq-wildcard-2017-08.cer,/certs/seq-wildcard-2017-08.key
```