### PR TITLE
remove pre-warmed image dbs, use plain postgres

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -28,14 +28,11 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_TRAEFIK v1.0.0
     env-import DOCKER_TAG_CONSUL 0.5
     env-import DOCKER_TAG_REGISTRATOR v5
-    env-import DOCKER_TAG_POSTGRES 9.4.1
     env-import DOCKER_TAG_POSTFIX latest
     env-import DOCKER_TAG_UAA 3.6.0
-    env-import DOCKER_TAG_UAADB v3.6.0
     env-import DOCKER_TAG_AMBASSADOR 0.5.0
     env-import DOCKER_TAG_CERT_TOOL 0.0.3
-    env-import DOCKER_TAG_CBDB 1.2.0
-    env-import DOCKER_TAG_PCDB 1.2.0
+    env-import DOCKER_TAG_POSTGRES 9.4.10-alpine
     env-import DOCKER_TAG_PERISCOPE 1.11.0-dev.16
     env-import DOCKER_TAG_CLOUDBREAK 1.11.0-dev.16
     env-import DOCKER_TAG_ULUWATU 1.11.0-dev.16

--- a/include/compose.bash
+++ b/include/compose.bash
@@ -303,7 +303,7 @@ uaadb:
         #- SERVICE_CHECK_CMD=bash -c 'psql -h 127.0.0.1 -p 5432  -U postgres -c "select 1"'
     volumes:
         - "uaadb:/var/lib/postgresql/data"
-    image: hortonworks/cloudbreak-uaa-db:$DOCKER_TAG_UAADB
+    image: postgres:$DOCKER_TAG_POSTGRES
 
 identity:
     labels:
@@ -337,7 +337,7 @@ cbdb:
         #- SERVICE_CHECK_CMD=bash -c 'psql -h 127.0.0.1 -p 5432  -U postgres -c "select 1"'
     volumes:
         - "cbdb:/var/lib/postgresql/data"
-    image: hortonworks/cloudbreak-server-db:$DOCKER_TAG_CBDB
+    image: postgres:$DOCKER_TAG_POSTGRES
 
 cloudbreak:
     environment:
@@ -523,7 +523,7 @@ pcdb:
         - "$PRIVATE_IP:5433:5432"
     volumes:
         - "periscopedb:/var/lib/postgresql/data"
-    image: hortonworks/cloudbreak-autoscale-db:$DOCKER_TAG_PCDB
+    image: postgres:$DOCKER_TAG_POSTGRES
 
 periscope:
     environment:


### PR DESCRIPTION
@mhmxs please review
@biharitomi this also Fixes: #281

there is not even 1% startup time change between dbs:
- starting from migrated db (63,2 sec)
- starting from 1.2 db version migrationg up (64,3 sec)
- starting from epmty library/postgres (63,76 sec)