### PR TITLE
Use latest uaa from 3.6.x branch

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -30,7 +30,7 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_REGISTRATOR v5
     env-import DOCKER_TAG_POSTGRES 9.4.1
     env-import DOCKER_TAG_POSTFIX latest
-    env-import DOCKER_TAG_UAA 3.6.0
+    env-import DOCKER_TAG_UAA 3.6.5
     env-import DOCKER_TAG_UAADB v3.6.0
     env-import DOCKER_TAG_AMBASSADOR 0.5.0
     env-import DOCKER_TAG_CERT_TOOL 0.0.3


### PR DESCRIPTION
WIP: @biharitomi please review

3.6.0 had security issues: https://github.com/hortonworks/docker-cloudbreak-uaa/issues/3

```cbd util token``` works fine but login stucks at Oauth confirmation: https://192.168.64.37/sl/confirm

```
Login/confirm: Error from token server, code: 403
```